### PR TITLE
chore: ensure cart store uses client-side persistence

### DIFF
--- a/mavigadget-clone/src/store/cart.ts
+++ b/mavigadget-clone/src/store/cart.ts
@@ -1,5 +1,7 @@
+'use client';
+
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import type { CartState, CartItem, Product } from '@/types';
 
 export const useCartStore = create<CartState>()(
@@ -82,6 +84,7 @@ export const useCartStore = create<CartState>()(
     }),
     {
       name: 'mavigadget-cart',
+      storage: createJSONStorage(() => (typeof window !== 'undefined' ? localStorage : (undefined as unknown as Storage))),
     }
   )
 );


### PR DESCRIPTION
## Summary
- use `use client` directive and JSON storage with localStorage for cart persistence

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f76f8e594832f9105e682792a3982